### PR TITLE
Add simple tools for updating and reading client statistics

### DIFF
--- a/dipla/client/statistics.py
+++ b/dipla/client/statistics.py
@@ -1,0 +1,48 @@
+class StatisticsUpdater:
+    """
+    A class to update and modify statistics.
+    All statistics modification should happen through this class exclusively.
+    """
+
+    def __init__(self, statistics):
+        """Creates a StatisticsUpdater, should ideally be called once."""
+        self.__statistics = statistics
+
+    def increment(self, statistic):
+        """Increments an integer statistic by 1."""
+        check_statistic_exists(statistic, self.__statistics)
+        self.__statistics[statistic] += 1
+
+    def overwrite(self, statistic, value):
+        """Overwrites a statistic's old value with a new one."""
+        check_statistic_exists(statistic, self.__statistics)
+        self.__statistics[statistic] = value
+
+
+class StatisticsReader:
+    """
+    A class to read statistics in an immutable way.
+    """
+
+    def __init__(self, statistics):
+        self.__statistics = statistics
+
+    def read(self, statistic):
+        """Fetch the value for a statistic."""
+        check_statistic_exists(statistic, self.__statistics)
+        return self.__statistics[statistic]
+
+    def read_all(self):
+        """Fetch an immutable dictionary of all statistics."""
+        return self.__statistics.copy()
+
+
+class StatisticsError(Exception):
+    pass
+
+
+def check_statistic_exists(statistic, statistics):
+    """Raise a StatisticsError if the statistic doesn't exist."""
+    if statistic not in statistics:
+        error_message = "Statistic {} does not exist".format(statistic)
+        raise StatisticsError(error_message)

--- a/dipla/client/statistics.py
+++ b/dipla/client/statistics.py
@@ -13,6 +13,10 @@ class StatisticsUpdater:
         check_statistic_exists(statistic, self.__statistics)
         self.__statistics[statistic] += 1
 
+    def decrement(self, statistic):
+        check_statistic_exists(statistic, self.__statistics)
+        self.__statistics[statistic] -= 1
+
     def overwrite(self, statistic, value):
         """Overwrites a statistic's old value with a new one."""
         check_statistic_exists(statistic, self.__statistics)

--- a/dipla/client/statistics.py
+++ b/dipla/client/statistics.py
@@ -10,12 +10,16 @@ class StatisticsUpdater:
 
     def increment(self, statistic):
         """Increments an integer statistic by 1."""
-        check_statistic_exists(statistic, self.__statistics)
-        self.__statistics[statistic] += 1
+        self.adjust(statistic, 1)
 
     def decrement(self, statistic):
+        """Decrements an integer statistic by 1"""
+        self.adjust(statistic, -1)
+
+    def adjust(self, statistic, amount):
+        """Adjust the value of a statistic by a specified amount"""
         check_statistic_exists(statistic, self.__statistics)
-        self.__statistics[statistic] -= 1
+        self.__statistics[statistic] += amount
 
     def overwrite(self, statistic, value):
         """Overwrites a statistic's old value with a new one."""

--- a/tests/client/statistics_test.py
+++ b/tests/client/statistics_test.py
@@ -25,6 +25,16 @@ class StatisticsUpdaterTest(unittest.TestCase):
         self.when_incrementing("y")
         self.then_the_statistic_is("y", 3)
 
+    def test_that_statistics_can_be_decremented_individually(self):
+        self.given_a_statistics_updater()
+        self.when_decrementing("x")
+        self.when_decrementing("x")
+        self.then_the_statistic_is("x", -2)
+        self.when_decrementing("y")
+        self.when_decrementing("y")
+        self.when_decrementing("y")
+        self.then_the_statistic_is("y", -3)
+
     def test_that_statistics_can_be_overwritten_individually(self):
         self.given_a_statistics_updater()
         self.when_overwriting("x", 500)
@@ -47,6 +57,9 @@ class StatisticsUpdaterTest(unittest.TestCase):
 
     def when_incrementing(self, statistic):
         self.statistics_updater.increment(statistic)
+
+    def when_decrementing(self, statistic):
+        self.statistics_updater.decrement(statistic)
 
     def when_overwriting(self, statistic, value):
         self.statistics_updater.overwrite(statistic, value)

--- a/tests/client/statistics_test.py
+++ b/tests/client/statistics_test.py
@@ -35,6 +35,15 @@ class StatisticsUpdaterTest(unittest.TestCase):
         self.when_decrementing("y")
         self.then_the_statistic_is("y", -3)
 
+    def test_that_statistics_can_be_adjusted_individually(self):
+        self.given_a_statistics_updater()
+        self.when_adjusting("x", 10)
+        self.when_adjusting("x", 5)
+        self.when_adjusting("y", 2)
+        self.when_adjusting("y", -1)
+        self.then_the_statistic_is("x", 15)
+        self.then_the_statistic_is("y", 1)
+
     def test_that_statistics_can_be_overwritten_individually(self):
         self.given_a_statistics_updater()
         self.when_overwriting("x", 500)
@@ -60,6 +69,9 @@ class StatisticsUpdaterTest(unittest.TestCase):
 
     def when_decrementing(self, statistic):
         self.statistics_updater.decrement(statistic)
+
+    def when_adjusting(self, statistic, amount):
+        self.statistics_updater.adjust(statistic, amount)
 
     def when_overwriting(self, statistic, value):
         self.statistics_updater.overwrite(statistic, value)

--- a/tests/client/statistics_test.py
+++ b/tests/client/statistics_test.py
@@ -1,0 +1,132 @@
+import unittest
+
+import functools
+
+from dipla.client.statistics import StatisticsUpdater,\
+                                    StatisticsReader,\
+                                    StatisticsError
+
+
+class StatisticsUpdaterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.statistics = {
+            "x": 0,
+            "y": 0
+        }
+
+    def test_that_statistics_can_be_incremented_individually(self):
+        self.given_a_statistics_updater()
+        self.when_incrementing("x")
+        self.when_incrementing("x")
+        self.then_the_statistic_is("x", 2)
+        self.when_incrementing("y")
+        self.when_incrementing("y")
+        self.when_incrementing("y")
+        self.then_the_statistic_is("y", 3)
+
+    def test_that_statistics_can_be_overwritten_individually(self):
+        self.given_a_statistics_updater()
+        self.when_overwriting("x", 500)
+        self.when_overwriting("y", 30)
+        self.then_the_statistic_is("x", 500)
+        self.then_the_statistic_is("y", 30)
+
+    def test_StatisticsError_is_raised_when_incrementing(self):
+        self.given_a_statistics_updater()
+        self.when_attempting_to_increment("z")
+        self.then_a_StatisticsError_is_raised()
+
+    def test_StatisticsError_is_raised_when_overwriting(self):
+        self.given_a_statistics_updater()
+        self.when_attempting_to_overwrite("z")
+        self.then_a_StatisticsError_is_raised()
+
+    def given_a_statistics_updater(self):
+        self.statistics_updater = StatisticsUpdater(self.statistics)
+
+    def when_incrementing(self, statistic):
+        self.statistics_updater.increment(statistic)
+
+    def when_overwriting(self, statistic, value):
+        self.statistics_updater.overwrite(statistic, value)
+
+    def when_attempting_to_increment(self, statistic):
+        self.operation = functools.partial(self.when_incrementing, statistic)
+
+    def when_attempting_to_overwrite(self, statistic):
+        arbitrary_value = 100
+        self.operation = functools.partial(self.when_overwriting,
+                                           statistic,
+                                           arbitrary_value)
+
+    def then_the_statistic_is(self, statistic, expected):
+        self.assertEqual(expected, self.statistics[statistic])
+
+    def then_a_StatisticsError_is_raised(self):
+        self.assertRaises(StatisticsError, self.operation)
+
+
+class StatisticsReaderTest(unittest.TestCase):
+
+    def setUp(self):
+        self.statistics = {
+            "x": 20,
+            "y": "healthy"
+        }
+
+    def test_that_individual_statistics_can_be_read(self):
+        self.given_a_statistics_reader()
+        self.when_reading("x")
+        self.then_the_value_is(20)
+        self.when_reading("y")
+        self.then_the_value_is("healthy")
+
+    def test_StatisticsError_is_raised_when_reading(self):
+        self.given_a_statistics_reader()
+        self.when_attempting_to_read("z")
+        self.then_a_StatisticsError_is_raised()
+
+    def test_that_all_statistics_can_be_read(self):
+        self.given_the_statistics_are({"a": 1, "b": 4})
+        self.given_a_statistics_reader()
+        self.when_reading_all()
+        self.then_the_statistics_are({"a": 1, "b": 4})
+
+    def test_that_statistics_are_immutable(self):
+        self.given_a_statistics_reader()
+        self.when_reading_all()
+        self.when_modifying("x", 200)
+        self.when_reading("x")
+        self.then_the_value_is(20)
+
+    def given_the_statistics_are(self, statistics):
+        self.statistics = statistics
+
+    def given_a_statistics_reader(self):
+        self.statistics_reader = StatisticsReader(self.statistics)
+
+    def when_reading(self, statistic):
+        self.value = self.statistics_reader.read(statistic)
+
+    def when_modifying(self, statistic, new_value):
+        self.value[statistic] = new_value
+
+    def when_attempting_to_read(self, statistic):
+        self.operation = functools.partial(self.when_reading, statistic)
+
+    def when_reading_all(self):
+        self.value = self.statistics_reader.read_all()
+
+    def then_the_value_is(self, expected):
+        self.assertEqual(expected, self.value)
+
+    def then_the_statistics_are(self, expected):
+        self.then_the_value_is(expected)
+
+    def then_a_StatisticsError_is_raised(self):
+        self.assertRaises(StatisticsError, self.operation)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New module: `dipla.client.statistics` that contains...
* A `StatisticsUpdater` for updating/writing stats at runtime.
* A `StatisticsReader` for reading stats at runtime.

There's technically only `48` changes here, the rest are test code.

:white_check_mark: Documentation included.
:white_check_mark: Tests included.
:white_check_mark: Commits squashed nicely (I hope).

The next mini task for me is to update these stats from within the real client.

@iandioch If you want, this can be dragged into the `dipla.shared` package and used for server stats too. That's your choice though.