### PR TITLE
Add multi-core support to client

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,6 @@ node {
       }
   
       stage ('Install pip dependencies') {
-        sh 'python3.5 -m easy_install pip'
         sh 'python3.5 -m pip install --upgrade -r requirements.txt'
       }
   

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ node {
       }
   
       stage ('Install pip dependencies') {
+        sh 'python3.5 -m easy_install pip'
         sh 'python3.5 -m pip install --upgrade -r requirements.txt'
       }
   

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node {
       }
   
       stage ('Install pip dependencies') {
-        sh 'python3.5 -m "pip" install --upgrade -r requirements.txt'
+        sh 'python3.5 -m pip install --upgrade -r requirements.txt'
       }
   
       stage ('Run python linter') {

--- a/run_client.py
+++ b/run_client.py
@@ -48,7 +48,7 @@ def main(argv):
 
 def run_n_clients(n, config):
     if n < 1:
-        raise Exception('Number of clients must be greater than 1')
+        raise Exception('Number of clients must be at least 1')
     elif n > multiprocessing.cpu_count():
         raise Exception('Number of clients must not exceed number of CPUs')
     processes = []
@@ -63,7 +63,8 @@ def run_n_clients(n, config):
         process.start()
         processes.append(process)
 
-    # Join each, one after the other, waiting until all are done to exit
+    # Join each thread, this function only returns once all the threads have
+    # exited.
     for proc in processes:
         proc.join()
 

--- a/run_client.py
+++ b/run_client.py
@@ -24,7 +24,7 @@ def main(argv):
     parser.add_argument('-c', default='', dest='config_path',
                         help="Optional path to a JSON config file")
     parser.add_argument('--cores', default=1, dest='cores', type=int,
-                        help="Number of concurent clients to run")
+                        help="Number of concurrent clients to run")
     parser.add_argument('--ui', action="store_true",
                         help="Use the Dipla Client UI")
     args = parser.parse_args()


### PR DESCRIPTION
Connects to #268 

Allows people running the client from the command line to connect multiple instances of the client to a server, better utilising their processing power. This is controlled with the `--cores` argument.