### PR TITLE
Add reduce functionality and example

### DIFF
--- a/dipla/api.py
+++ b/dipla/api.py
@@ -66,7 +66,6 @@ class Dipla:
         return len(stream) > 0
 
     def _create_clientside_task(task_instructions, is_reduce=False, reduce_group_size=2):
-        print("_create_clientside_task:", reduce_group_size)
         task_uid = uid_generator.generate_uid(
             length=8,
             existing_uids=Dipla.task_queue.get_task_ids())
@@ -108,10 +107,6 @@ class Dipla:
         sources are objects that can be used to create a data source,
         e.g. an iterable or another task
         """
-        print("_create_normal_task", reduce_group_size)
-        print(task_instructions)
-        print(Dipla._reduce_task_group_sizes)
-        print(id(task_instructions))
         task = Dipla._create_clientside_task(task_instructions, is_reduce, reduce_group_size)
 
         source_uids = []

--- a/dipla/api.py
+++ b/dipla/api.py
@@ -104,12 +104,17 @@ class Dipla:
             task.add_data_source(
                 create_data_source_function(source, data_source_creator))
 
-    def _create_normal_task(sources, task_instructions, is_reduce=False, reduce_group_size=2):
+    def _create_normal_task(sources,
+                            task_instructions,
+                            is_reduce=False,
+                            reduce_group_size=2):
         """
         sources are objects that can be used to create a data source,
         e.g. an iterable or another task
         """
-        task = Dipla._create_clientside_task(task_instructions, is_reduce, reduce_group_size)
+        task = Dipla._create_clientside_task(task_instructions,
+                                             is_reduce,
+                                             reduce_group_size)
 
         source_uids = []
 
@@ -146,20 +151,20 @@ class Dipla:
         then registered with the BinaryManager.
 
         A reduce function is one which takes a number of inputs, and returns a
-        single
-        value. This value is then added back to the list of inputs for the function.
-        This process is repeated until there is only one value left, which is given
-        as the result.
+        single value. This value is then added back to the list of inputs for
+        the function. This process is repeated until there is only one value
+        left, which is given as the result.
 
-        The reduce function given here should expect a single parameter, which will
-        be the list of values to reduce. You can provide a parameter `n` to this
-        decorator; this denotes the maximum number of inputs that will be given to
-        the reduce function at a time. It defaults to 2, which is the standard case
-        for a canonical reduce function. Raising this number may increase
-        performance."""
+        The reduce function given here should expect a single parameter, which
+        will be the list of values to reduce. You can provide a parameter `n`
+        to this decorator; this denotes the maximum number of inputs that will
+        be given to the reduce function at a time. It defaults to 2, which is
+        the standard case for a canonical reduce function. Raising this number
+        may increase performance in some cases."""
 
         if n <= 1:
-            raise ReduceBadSize("Input size for a reduce must be greater than 1")
+            s = "Input size for a reduce function must be greater than 1"
+            raise ReduceBadSize(s)
 
         def distributable_decorator(function):
             Dipla._process_decorated_function(function, None)
@@ -322,7 +327,8 @@ class Dipla:
         is_reduce = id(function) in Dipla._reduce_task_group_sizes
 
         if is_reduce and len(raw_args) != 1:
-            raise KeyError("Incorrect number of arguments given for reduce distributable")
+            s = "Incorrect number of arguments given for reduce distributable"
+            raise KeyError(s)
 
         args = []
         for arg in raw_args:
@@ -335,11 +341,11 @@ class Dipla:
         function_id = id(function)
         task = None
         if is_reduce:
-            group_size = Dipla._reduce_task_group_sizes[id(function)]
+            size = Dipla._reduce_task_group_sizes[function_id]
             task = Dipla._task_creators[function_id](args,
                                                      function.__name__,
                                                      is_reduce=True,
-                                                     reduce_group_size=group_size)
+                                                     reduce_group_size=size)
         else:
             task = Dipla._task_creators[function_id](args, function.__name__)
 
@@ -414,7 +420,6 @@ class Dipla:
             client.terminate()
         else:
             server.start(password=Dipla._password)
-
 
         if Dipla.task_queue.get_task(promise.task_uid).is_reduce:
             # The task that has been requested is a reduce task,

--- a/dipla/api.py
+++ b/dipla/api.py
@@ -144,20 +144,20 @@ class Dipla:
         return distributable_decorator
 
     @staticmethod
-    def reduce_distributable(reduce_group_size=2):
+    def reduce_distributable(n=2):
         """Takes a function that should expect a single parameter of a list of
-        values to reduce, and registers it with the BinaryManager."""
+        values to reduce, and registers it with the BinaryManager. You can give
+        it a parameter `n` - this denotes up to how many values should be given
+        to the reduce function at a time (defaults to 2). Raising this number
+        may increase performance."""
 
         def distributable_decorator(function):
             Dipla._process_decorated_function(function, None)
             Dipla._task_creators[id(function)] = Dipla._create_normal_task
-            print('reduce_group_size = ', reduce_group_size)
-            print(function)
-            Dipla._reduce_task_group_sizes[id(function)] = reduce_group_size
+            Dipla._reduce_task_group_sizes[id(function)] = n
             return function
 
         return distributable_decorator
-        
 
     @staticmethod
     def scoped_distributable(count, verifier=None):
@@ -309,8 +309,6 @@ class Dipla:
         if id(function) not in Dipla._task_creators:
             raise KeyError("Provided function was not decorated using Dipla")
 
-        print('apply_distributable!')
-
         is_reduce = id(function) in Dipla._reduce_task_group_sizes
 
         if is_reduce and len(raw_args) != 1:
@@ -327,9 +325,7 @@ class Dipla:
         function_id = id(function)
         task = None
         if is_reduce:
-            print('we have a reduce!')
             group_size = Dipla._reduce_task_group_sizes[id(function)]
-            print("apply_distributable: ", group_size)
             task = Dipla._task_creators[function_id](args,
                                                      function.__name__,
                                                      is_reduce=True,

--- a/dipla/api.py
+++ b/dipla/api.py
@@ -144,7 +144,9 @@ class Dipla:
         values to reduce, and registers it with the BinaryManager."""
 
         def distributable_decorator(function):
+            Dipla._process_decorated_function(function, None)
             Dipla._task_creators[id(function)] = Dipla._create_normal_task
+            print('reduce_group_size = ', reduce_group_size)
             Dipla._reduce_task_group_sizes[id(function)] = reduce_group_size
             return function
 
@@ -317,14 +319,11 @@ class Dipla:
         function_id = id(function)
         task = None
         if is_reduce:
-            print('creating reduce task')
             group_size = Dipla._reduce_task_group_sizes[id(function)]
-            print('group size =', group_size)
             task = Dipla._task_creators[function_id](args,
                                                      function.__name__,
                                                      is_reduce=True,
                                                      reduce_group_size=group_size)
-            print(args)
         else:
             task = Dipla._task_creators[function_id](args, function.__name__)
 

--- a/dipla/server/task_queue.py
+++ b/dipla/server/task_queue.py
@@ -49,7 +49,6 @@ class TaskQueue:
         if item.uid is None:
             raise AttributeError("Added task to TaskQueue with no id")
         if item.is_reduce:
-            print('creating reducetaskqueuenode')
             self._nodes[item.uid] = ReduceTaskQueueNode(item, item.reduce_group_size)
         else:
             self._nodes[item.uid] = TaskQueueNode(item)
@@ -163,13 +162,11 @@ class TaskQueue:
             # This task has been marked as a reduce task, so outputs should be
             # put back into the same task as an input.
 
-            print('push_task_input({}, [{}])'.format(task_id, result))
             # self.push_task_input() expects a series of groups of inputs,
             # (one group of inputs is the things a task needs to run once)
             # so we must turn this single value into that format
             args = [[result]]
             self.push_task_input(task_id, args)
-        print('add_result continuing')
 
         if self.is_task_open(task_id):
             self.activate_new_tasks(self._nodes[task_id].dependees)
@@ -306,13 +303,11 @@ class ReduceTaskQueueNode(TaskQueueNode):
             argument_id = dependency.source_uid
             arg = dependency.data_streamer.read()
 
-            print("arg:", arg)
             arguments.append(arg[0])
 
             # if we are not adding things one by one
             if len(arguments) >= self.reduce_group_size:
                 break
-        print("arguments:", arguments)
         arguments = [[arguments]]
 
         # Not very pretty, but expect a result for every element in the args

--- a/dipla/server/task_queue.py
+++ b/dipla/server/task_queue.py
@@ -49,7 +49,8 @@ class TaskQueue:
         if item.uid is None:
             raise AttributeError("Added task to TaskQueue with no id")
         if item.is_reduce:
-            self._nodes[item.uid] = ReduceTaskQueueNode(item, item.reduce_group_size)
+            group_size = item.reduce_group_size
+            self._nodes[item.uid] = ReduceTaskQueueNode(item, group_size)
         else:
             self._nodes[item.uid] = TaskQueueNode(item)
 

--- a/dipla/server/task_queue.py
+++ b/dipla/server/task_queue.py
@@ -268,7 +268,7 @@ class TaskQueueNode:
             self.task_item.instructions,
             self.task_item.machine_type,
             arguments,
-            signals=[x for x in self.task_item.signals])
+            signals=list(self.task_item.signals))
 
     def has_next_input(self):
         if len(self.dependencies) == 0:
@@ -297,7 +297,7 @@ class ReduceTaskQueueNode(TaskQueueNode):
                 "Attempted to read input from an empty source")
         arguments = []
 
-        for i in range(self.reduce_group_size):
+        for _ in range(self.reduce_group_size):
             dependency = self.dependencies[0]
             if not dependency.data_streamer.has_available_data():
                 break
@@ -318,7 +318,7 @@ class ReduceTaskQueueNode(TaskQueueNode):
             self.task_item.instructions,
             self.task_item.machine_type,
             arguments,
-            signals=[x for x in self.task_item.signals])
+            signals=list(self.task_item.signals))
 
 
 class DataStreamerEmpty(Exception):

--- a/examples/reduce.py
+++ b/examples/reduce.py
@@ -1,0 +1,46 @@
+from os import path
+import sys
+# Append to path so that this script can access the dipla package
+sys.path.append(path.abspath('../dipla'))
+
+from dipla.api import Dipla
+
+# This program finds the word with the most vowels from the opening of the Communist Manifesto
+
+communist_manifesto = """
+ A spectre is haunting Europe — the spectre of communism. All the powers of old Europe have entered into a holy alliance to exorcise this spectre: Pope and Tsar, Metternich and Guizot, French Radicals and German police-spies.
+
+Where is the party in opposition that has not been decried as communistic by its opponents in power? Where is the opposition that has not hurled back the branding reproach of communism, against the more advanced opposition parties, as well as against its reactionary adversaries?
+
+Two things result from this fact:
+
+I. Communism is already acknowledged by all European powers to be itself a power.
+
+II. It is high time that Communists should openly, in the face of the whole world, publish their views, their aims, their tendencies, and meet this nursery tale of the Spectre of Communism with a manifesto of the party itself.
+
+To this end, Communists of various nationalities have assembled in London and sketched the following manifesto, to be published in the English, French, German, Italian, Flemish and Danish languages. 
+"""
+
+input_data = [word.lower() for word in communist_manifesto.split() if len(word) > 0]
+print(input_data)
+
+@Dipla.reduce_distributable(reduce_group_size=5)
+def find_most_vowels(words):
+    vowels = set(['a', 'e', 'i', 'o', 'u'])
+    best = ""
+    best_count = -1
+    for word in words:
+        n = 0
+        for c in word:
+            if c in vowels:
+                n += 1
+        if n > best_count:
+            best_count = n
+            best = word
+    return best
+
+print("input data:", input_data)
+
+out = Dipla.apply_distributable(find_most_vowels, input_data).get()
+
+print('result:', out)

--- a/examples/reduce.py
+++ b/examples/reduce.py
@@ -23,7 +23,7 @@ To this end, Communists of various nationalities have assembled in London and sk
 
 input_data = [word.lower() for word in communist_manifesto.split() if len(word) > 0]
 
-@Dipla.reduce_distributable(n = 6)
+@Dipla.reduce_distributable(n=6)
 def find_most_vowels(words):
     vowels = set(['a', 'e', 'i', 'o', 'u'])
     best = ""

--- a/examples/reduce.py
+++ b/examples/reduce.py
@@ -22,9 +22,8 @@ To this end, Communists of various nationalities have assembled in London and sk
 """
 
 input_data = [word.lower() for word in communist_manifesto.split() if len(word) > 0]
-print(input_data)
 
-@Dipla.reduce_distributable(reduce_group_size=5)
+@Dipla.reduce_distributable(n = 6)
 def find_most_vowels(words):
     vowels = set(['a', 'e', 'i', 'o', 'u'])
     best = ""


### PR DESCRIPTION
Connects to #266.

This creates a `@Dipla.reduce_distributable` decorator. You can see its use in `examples/reduce.py`, which finds the word with the most vowels in the opening of the communist manifesto by a reduce function.

The decorator takes a parameter, `n`. This is the number of inputs to take in one go. A normal reduce takes 2 inputs, however it was suggested that this number could be raised to get better performance by reducing the number of requests sent across the wire. This is left up to the user.

It is a little over the 150 line limit, but that is probably caused by the inclusion of the example.

Let me know what you think xoxo